### PR TITLE
added optional param table_name to sorting_order method

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ To sort your records, add this line:
 records.sorting_order(order)
 ```
 
+If your table's name isn't the tableize version of your model you can pass a custom table_name:
+```ruby
+records.sorting_order(order, table_name)
+```
+
 Call the helper on your view:
 ```ruby
 <th><%= sortable 'id', t(:id, scope: :systems) %></th>

--- a/lib/sort_n_params/concerns/scopes.rb
+++ b/lib/sort_n_params/concerns/scopes.rb
@@ -4,7 +4,7 @@ module SortNParams
   module Scopes
     extend ActiveSupport::Concern
     class_methods do
-      def sorting_order(ordering_array, table_name)
+      def sorting_order(ordering_array, table_name = nil)
         return all if ordering_array.blank?
 
         all.order(parse_array(ordering_array, table_name))

--- a/lib/sort_n_params/concerns/scopes.rb
+++ b/lib/sort_n_params/concerns/scopes.rb
@@ -10,7 +10,7 @@ module SortNParams
         all.order(parse_array(ordering_array, table_name))
       end
 
-      def parse_array(ordering_array, table_name)
+      def parse_array(ordering_array, table_name = nil)
         table = table_name || name.tableize
 
         ordering_array.each_slice(2).map do |order, direction|

--- a/lib/sort_n_params/concerns/scopes.rb
+++ b/lib/sort_n_params/concerns/scopes.rb
@@ -4,15 +4,17 @@ module SortNParams
   module Scopes
     extend ActiveSupport::Concern
     class_methods do
-      def sorting_order(ordering_array)
+      def sorting_order(ordering_array, table_name)
         return all if ordering_array.blank?
 
-        all.order(parse_array(ordering_array))
+        all.order(parse_array(ordering_array, table_name))
       end
 
-      def parse_array(ordering_array)
+      def parse_array(ordering_array, table_name)
+        table = table_name || name.tableize
+
         ordering_array.each_slice(2).map do |order, direction|
-          "#{name.tableize}.#{order} #{direction}"
+          "#{table}.#{order} #{direction}"
         end.join(', ')
       end
     end

--- a/spec/concerns/scopes_spec.rb
+++ b/spec/concerns/scopes_spec.rb
@@ -1,0 +1,25 @@
+require 'sort_n_params/concerns/scopes'
+
+RSpec.describe SortNParams::Scopes do
+  let(:test_class) do
+    CustomTable = Struct.new(:custom_field) do
+      include SortNParams::Scopes
+    end
+  end
+
+  context 'when you pass only an ordering array' do
+    subject { test_class.parse_array(["test_field","asc"]) }
+
+    it "builds the array correctly with the table_name param passed" do
+      expect(subject).to eq("custom_tables.test_field asc")
+    end
+  end
+
+  context 'when you pass both ordering array and table name' do
+    subject { test_class.parse_array(["test_field","asc"], "another_table_name" ) }
+
+    it "builds the array correctly with the table_name param passed" do
+      expect(subject).to eq("another_table_name.test_field asc")
+    end
+  end
+end

--- a/spec/concerns/scopes_spec.rb
+++ b/spec/concerns/scopes_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe SortNParams::Scopes do
   context 'when you pass both ordering array and table name' do
     subject { test_class.parse_array(["test_field","asc"], "another_table_name" ) }
 
-    it "builds the array correctly without the table_name param passed" do
+    it "builds the array correctly with the table_name param passed" do
       expect(subject).to eq("another_table_name.test_field asc")
     end
   end

--- a/spec/concerns/scopes_spec.rb
+++ b/spec/concerns/scopes_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe SortNParams::Scopes do
   context 'when you pass both ordering array and table name' do
     subject { test_class.parse_array(["test_field","asc"], "another_table_name" ) }
 
-    it "builds the array correctly with the table_name param passed" do
+    it "builds the array correctly without the table_name param passed" do
       expect(subject).to eq("another_table_name.test_field asc")
     end
   end

--- a/spec/concerns/scopes_spec.rb
+++ b/spec/concerns/scopes_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SortNParams::Scopes do
   context 'when you pass only an ordering array' do
     subject { test_class.parse_array(["test_field","asc"]) }
 
-    it "builds the array correctly with the table_name param passed" do
+    it "builds the array correctly without the table_name param passed" do
       expect(subject).to eq("custom_tables.test_field asc")
     end
   end


### PR DESCRIPTION
When working with STI or long name models, the table's name differs from what a model.tableize would be. This changes allows you to pass the custom table's name to the sorting_order method. 